### PR TITLE
#47 プロフィール画像の投稿機能を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,6 @@ class ApplicationController < ActionController::Base
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:user_name, :image])
       devise_parameter_sanitizer.permit(:sign_in, keys: [:user_name])
-      devise_parameter_sanitizer.permit(:account_update, keys: [:user_name])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:user_name, :image])
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,8 @@
 #
 
 class User < ApplicationRecord
+  mount_uploader :image, ImageUploader
+  
   has_many :boards, dependent: :delete_all
 
   validates :user_name, presence: true, length: { maximum: 10 }
@@ -32,6 +34,4 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
-
-  mount_uploader :image, ImageUploader
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -30,26 +30,33 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Create different versions of your uploaded files:
   # version :thumb do
-  process resize_to_fit: [50, 50]
-  # end
-  process :convert => 'jpg'
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
-  def extension_whitelist
-    %w(jpg jpeg gif png)
-  end
+  #上限変更
+    process :resize_to_limit => [300, 300]
 
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  def filename
-    "something.jpg" if original_filename
-  end
+  #JPGで保存
+    process :convert => 'jpg'
 
-  def filename
-    if original_filename.present?
-      time = Time.now
-      name = time.strftime('%Y%m%d%H%M%S') + '.jpg'
-      name.downcase
+  #サムネイルを生成
+    version :thumb do
+      process :resize_to_limit => [100, 100]
     end
-  end
+
+  # jpg,jpeg,gif,pngのみ
+    def extension_white_list
+      %w(jpg jpeg gif png)
+    end
+
+  #ファイル名を変更し拡張子を同じにする
+    def filename
+      super.chomp(File.extname(super)) + '.jpg'
+    end
+
+  #日付で保存
+    def filename
+      if original_filename.present?
+        time = Time.now
+        name = time.strftime('%Y%m%d%H%M%S') + '.jpg'
+        name.downcase
+      end
+    end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -9,6 +9,11 @@
   </div>
 
   <div class="field">
+    <%= f.label :image %><br/>
+    <%= f.file_field :image %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,6 +8,11 @@
   </div>
 
   <div class="field">
+    <%= f.label :image %><br/>
+    <%= f.file_field :image %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module App
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
     config.time_zone = "Tokyo"
-    config.i18n.default_locale = :ja 
+    config.i18n.default_locale = :ja
+    config.autoload_paths += Dir[Rails.root.join('app', 'uploaders')]
   end
 end

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -3,13 +3,14 @@ ja:
     attributes:
       user:
         user_name: "ユーザー名"
+        image: プロフィール画像
         current_password: "現在のパスワード"
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "確認用パスワード"
         remember_me: "ログインを記憶"
     models:
-      user: "ユーザ"
+      user: "ユーザー"
   devise:
     confirmations:
       new:


### PR DESCRIPTION
①アップローダーの設定ファイル、モデルへのマウント記述を修正しました
②ユーザー編集アクションのストロングパラメータにimageを追加
③ユーザー登録、編集ページに画像選択フォームを追加
④localファイルの細かい修正