### PR TITLE
#62 dependentオプションのエラーを修正

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -21,9 +21,9 @@
 #
 
 class Board < ApplicationRecord
-  has_many :comments, dependent: :delete_all
+  has_many :comments, dependent: :destroy
   belongs_to :category
-  belongs_to :user, dependent: :destroy
+  belongs_to :user
 
   validates :name, presence: true, length: { maximum: 8 }
   validates :title, presence: true, length: { maximum: 20 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,8 +27,8 @@
 class User < ApplicationRecord
   mount_uploader :image, ImageUploader
 
-  has_many :boards, dependent: :delete_all
-  has_many :comments, dependent: :delete_all
+  has_many :boards, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   validates :user_name, presence: true, length: { maximum: 10 }
   # Include default devise modules. Others available are:


### PR DESCRIPTION
①主テーブル(users,boards)の主データを削除した場合に関連する子データ(boards,comments)を削除できないエラーを修正